### PR TITLE
Provided clickable link and cmd to activate bot

### DIFF
--- a/praise-bot/app.js
+++ b/praise-bot/app.js
@@ -156,7 +156,10 @@ app.view('praise_form', async ({ ack, body, view, client, logger}) => {
   else {
     message_txt = `*Hey <@${receiver}>!*` + 
       `<@${sender}> wanted to share some kind words with you :otter:\n` +
-      `> ${message}\n` + `<${gif}>`
+      `> ${message}\n` + `<${gif}>` +
+      `\n\nYou can check out this praise at <https://ohack.dev/praise|ohack.dev/praise>. If you don't see it, `
+      + `please report the issue in #slack-bot-dev.` +
+      `\n\nWant to send a praise too? Type \`/praise\` to open and submit a form.`
   }
 
   // Post message in the channel or to the user


### PR DESCRIPTION
Modified text message on successful praise message by adding the following string messages:

- The url to check out praises written about them or others when clicked on (Video to show that clicking the URL will take them to the praise board on ohack.dev)
- The command to type so that receivers can also write a praise in case they joined OHack after release of Praise Bot (Screenshot with red underline provided for visibility)


https://github.com/user-attachments/assets/b2edeb64-2a86-4395-bdc0-ee1522c272af
<img width="839" height="457" alt="image" src="https://github.com/user-attachments/assets/0201fed7-7ffe-466b-b38b-9e4b4141eaf2" />

